### PR TITLE
Prevent accidental illegal CRLF on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+src/tsc-bundle eol=lf


### PR DESCRIPTION
tsc-bundle@1.0.16 doesn't run after installation, yielding instead the
error

    /usr/bin/env: ‘node\r’: No such file or directory

Classic EOL script error that can be resolved with

    $ dos2unix node_modules/.bin/tsc-bundle

The source file doesn't contain CR, however, so the most likely cause of
the error is a distribution produced by a checkout that performed
undesirable EOL conversion, such as many typical `core.autocrlf` Windows
setups. Instruct Git to stop with such shenanigans. This doesn't fix #16
directly and is not technically guaranteed to fix it at all but it does
make it harder to introduce the error.

You should run

```sh
$ rm src/tsc-bundle && git checkout -- src/tsc-bundle
```

to make sure the file is updated in the working tree after this.