### PR TITLE
Fix error when bundling json modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": " A zero configuration bundling tool for TypeScript.",
   "scripts": {
     "clean": "smoke-task clean",
-    "amd-loaders": "node tasks amd_loaders",
+    "amd-loaders": "smoke-task amd_loaders",
     "build": "smoke-task build",
     "pack": "smoke-task pack",
     "spec": "smoke-task spec",

--- a/readme.md
+++ b/readme.md
@@ -288,7 +288,7 @@ The following tasks are provided by this project.
 
 ```bash
 $ npm run clean       # cleans this project.
-$ npm run es_loaders  # rebuilds es loader templates. 
+$ npm run amd-loaders # rebuilds es loader templates. 
 $ npm run build       # builds the bundler.
 $ npm run pack        # packs the bundler.
 $ npm run spec        # builds and runs the spec project.

--- a/src/bundler/loader/templates/es2015.ts
+++ b/src/bundler/loader/templates/es2015.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/es2016.ts
+++ b/src/bundler/loader/templates/es2016.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/es2017.ts
+++ b/src/bundler/loader/templates/es2017.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/es2018.ts
+++ b/src/bundler/loader/templates/es2018.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/es3.ts
+++ b/src/bundler/loader/templates/es3.ts
@@ -40,6 +40,9 @@ export default `(function () {
             return {};
         }
         var define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         var dependencies = define.dependencies.map(function (name) { return resolve(name); });
         define.factory.apply(define, dependencies);

--- a/src/bundler/loader/templates/es5.ts
+++ b/src/bundler/loader/templates/es5.ts
@@ -40,6 +40,9 @@ export default `(function () {
             return {};
         }
         var define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         var dependencies = define.dependencies.map(function (name) { return resolve(name); });
         define.factory.apply(define, dependencies);

--- a/src/bundler/loader/templates/es6.ts
+++ b/src/bundler/loader/templates/es6.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/esnext.ts
+++ b/src/bundler/loader/templates/esnext.ts
@@ -40,6 +40,9 @@ export default `(() => {
             return {};
         }
         const define = get_define(name);
+        if (typeof define.factory !== 'function') {
+            return define.factory;
+        }
         instances[name] = {};
         const dependencies = define.dependencies.map(name => resolve(name));
         define.factory(...dependencies);

--- a/src/bundler/loader/templates/template.ts
+++ b/src/bundler/loader/templates/template.ts
@@ -173,12 +173,16 @@ interface Instance {
     // resolve module definition.
     const define = get_define(name)
 
+    if (typeof define.factory !== 'function') {
+      return define.factory
+    }
+
     // set instance (note: prevents stack overflow of cyclic import)
     instances[name] = {}
 
     // resolve module dependencies.
     const dependencies = define.dependencies.map(name => resolve(name))
-    
+
     // execute module factory.
     define.factory(...dependencies)
     


### PR DESCRIPTION
When bundling json modules, the factory code contains an object instead of a function.
```javascript
define("resolve-to-json-module", [], {
  /* json file content */
});
```

However, current template expects function
```javascript
// src/bundler/loader/templates/template.ts
const dependencies = define.dependencies.map(name => resolve(name));
define.factory(...dependencies); // <-- error! define.factory is not callable!
const exports = dependencies[define.dependencies.indexOf('exports')];
```

Fixed by returning the object directly without calling it.